### PR TITLE
Fix errors caused by thor upgrade

### DIFF
--- a/lib/collins_shell/asset.rb
+++ b/lib/collins_shell/asset.rb
@@ -37,7 +37,7 @@ module CollinsShell
     use_tag_option(true)
     use_nuke_option(true)
     method_option :reason, :required => true, :type => :string, :desc => 'Reason to delete asset'
-    method_option :nuke, :required => false, :type => :boolean, :default => :false, :desc => 'Destroy asset forever?'
+    method_option :nuke, :required => false, :type => :boolean, :default => false, :desc => 'Destroy asset forever?'
     def delete
       call_collins get_collins_client, "delete asset" do |client|
         if client.delete!(options.tag, :reason => options.reason, :nuke => options.nuke) then
@@ -51,7 +51,7 @@ module CollinsShell
     desc 'find', 'find assets using the specified selector'
     use_collins_options
     use_selector_option(true)
-    method_option :confirm, :type => :boolean, :default => :true, :desc => 'Require exec confirmation. Defaults to true'
+    method_option :confirm, :type => :boolean, :default => true, :desc => 'Require exec confirmation. Defaults to true'
     method_option :details, :type => :boolean, :desc => 'Output assets how you see them in get'
     method_option :exec, :type => :string, :desc => 'Execute a command using the data from this asset. Use {{hostname}}, {{ipmi.password}}, etc for substitution'
     method_option :header, :type => :boolean, :default => true, :desc => 'Display a tag header. Defaults to true'
@@ -111,7 +111,7 @@ module CollinsShell
 
     desc 'get TAG', 'get an asset and display its attributes'
     use_collins_options
-    method_option :confirm, :type => :boolean, :default => :true, :desc => 'Require exec confirmation. Defaults to true'
+    method_option :confirm, :type => :boolean, :default => true, :desc => 'Require exec confirmation. Defaults to true'
     method_option :exec, :type => :string, :desc => 'Execute a command using the data from this asset. Use {{hostname}}, {{ipmi.password}}, etc for substitution'
     method_option :logs, :type => :boolean, :default => false, :desc => 'Also display asset logs'
     method_option :remote, :type => :string, :desc => 'Remote location to search. This is a tag in collins corresponding to the datacenter asset'

--- a/lib/collins_shell/provision.rb
+++ b/lib/collins_shell/provision.rb
@@ -51,13 +51,13 @@ module CollinsShell
     D
     use_collins_options
     method_option :activate, :type => :boolean, :desc => 'Activate a server', :hide => true
-    method_option :confirm, :type => :boolean, :default => :true, :desc => 'Require confirmation. Defaults to true'
+    method_option :confirm, :type => :boolean, :default => true, :desc => 'Require confirmation. Defaults to true'
     method_option :exec, :type => :string, :desc => 'Execute a command using the data from this asset. Use {{hostname}}, {{ipmi.password}}, etc for substitution'
     method_option :pool, :type => :string, :desc => 'Pool for host'
     method_option :primary_role, :type => :string, :desc => 'Primary role for host'
     method_option :secondary_role, :type => :string, :desc => 'Secondary role for host'
     method_option :suffix, :type => :string, :desc => 'Suffix to use for hostname'
-    method_option :verify, :type => :boolean, :default => :true, :desc => 'Verify arguments locally first'
+    method_option :verify, :type => :boolean, :default => true, :desc => 'Verify arguments locally first'
     def host tag, profile, contact
       verify_profile(profile) if options.verify
       config = get_collins_config

--- a/lib/collins_shell/thor.rb
+++ b/lib/collins_shell/thor.rb
@@ -46,7 +46,7 @@ module CollinsShell
       method_option :tag, :type => :string, :required => required, :desc => 'Tag for asset'
     end
     def use_nuke_option required = false
-      method_option :nuke, :required => required, :default => :false, :desc => 'Nuke to destroy'
+      method_option :nuke, :required => required, :default => false, :desc => 'Nuke to destroy'
     end
     def use_selector_option required = false
       method_option :selector, :type => :hash, :required => required, :desc => 'Selector to query collins. Takes the form of --selector=key1:val1 key2:val2 etc'


### PR DESCRIPTION
The thor upgrade in d61033a0aa1cbd21fd8aadf1f186b4a206b3231b caused a
bunch of errors when running collins-shell:

```
$ collins-shell version
Expected boolean default value for '--nuke'; got :false (string)
Expected boolean default value for '--confirm'; got :true (string)
Expected boolean default value for '--confirm'; got :true (string)
Expected boolean default value for '--confirm'; got :true (string)
Expected boolean default value for '--verify'; got :true (string)
collins-shell 0.2.26
```

This fixes those errors by replacing the symbol with the boolean.